### PR TITLE
scripts/dtc: Update to upstream version v1.6.1-60-g98a0700

### DIFF
--- a/scripts/dtc/libfdt/fdt.c
+++ b/scripts/dtc/libfdt/fdt.c
@@ -106,7 +106,6 @@ int fdt_check_header(const void *fdt)
 	}
 	hdrsize = fdt_header_size(fdt);
 	if (!can_assume(VALID_DTB)) {
-
 		if ((fdt_totalsize(fdt) < hdrsize)
 		    || (fdt_totalsize(fdt) > INT_MAX))
 			return -FDT_ERR_TRUNCATED;
@@ -115,9 +114,7 @@ int fdt_check_header(const void *fdt)
 		if (!check_off_(hdrsize, fdt_totalsize(fdt),
 				fdt_off_mem_rsvmap(fdt)))
 			return -FDT_ERR_TRUNCATED;
-	}
 
-	if (!can_assume(VALID_DTB)) {
 		/* Bounds check structure block */
 		if (!can_assume(LATEST) && fdt_version(fdt) < 17) {
 			if (!check_off_(hdrsize, fdt_totalsize(fdt),

--- a/scripts/dtc/version_gen.h
+++ b/scripts/dtc/version_gen.h
@@ -1,1 +1,1 @@
-#define DTC_VERSION "DTC 1.6.1-ge37c2567"
+#define DTC_VERSION "DTC 1.6.1-g98a07006"


### PR DESCRIPTION
This adds the following commits from upstream:

98a0700 Makefile: fix infinite recursion by dropping non-existent `%.output`
a036cc7 Makefile: limit make re-execution to avoid infinite spin
c6e9210 libdtc: remove duplicate judgments

Signed-off-by: Tashfin Shakeer Rhythm <tashfinshakeerrhythm@gmail.com>