### PR TITLE
ANDROID: extract-cert: omit PKCS#11 support if building against Borin…

### DIFF
--- a/scripts/extract-cert.c
+++ b/scripts/extract-cert.c
@@ -56,6 +56,7 @@ static void display_openssl_errors(int l)
 	}
 }
 
+#ifndef OPENSSL_IS_BORINGSSL
 static void drain_openssl_errors(void)
 {
 	const char *file;
@@ -65,6 +66,7 @@ static void drain_openssl_errors(void)
 		return;
 	while (ERR_get_error_line(&file, &line)) {}
 }
+#endif
 
 #define ERR(cond, fmt, ...)				\
 	do {						\
@@ -119,6 +121,10 @@ int main(int argc, char **argv)
 		fclose(f);
 		exit(0);
 	} else if (!strncmp(cert_src, "pkcs11:", 7)) {
+#ifdef OPENSSL_IS_BORINGSSL
+		ERR(1, "BoringSSL does not support extracting from PKCS#11");
+		exit(1);
+#else
 		ENGINE *e;
 		struct {
 			const char *cert_id;
@@ -141,6 +147,7 @@ int main(int argc, char **argv)
 		ENGINE_ctrl_cmd(e, "LOAD_CERT_CTRL", 0, &parms, NULL, 1);
 		ERR(!parms.cert, "Get X.509 from PKCS#11");
 		write_cert(parms.cert);
+#endif
 	} else {
 		BIO *b;
 		X509 *x509;


### PR DESCRIPTION
…gSSL

BoringSSL does not implement the ENGINE API. In Android we do not seem to rely on the PKCS#11 -> DER extraction. Hence, make this conditional on the SSL library used.

Bug: 135570712

Change-Id: I84af6633dd470083497087c7dd1a2734480e2b0e